### PR TITLE
Make sort locale independent

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const compare = (ak, bk, prefKeys) =>
   : prefKeys.includes(bk) && !prefKeys.includes(ak) ? 1
   : prefKeys.includes(ak) && prefKeys.includes(bk)
     ? prefKeys.indexOf(ak) - prefKeys.indexOf(bk)
-  : ak.localeCompare(bk)
+  : ak > bk ? 1 : (ak < bk ? -1 : 0)
 
 const sort = (replacer, seen) => (key, val) => {
   const prefKeys = Array.isArray(replacer) ? replacer : []

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 const isObj = val => !!val && !Array.isArray(val) && typeof val === 'object'
 
-const compare = (ak, bk, prefKeys) =>
+const compare = (ak, bk, prefKeys, locale) =>
   prefKeys.includes(ak) && !prefKeys.includes(bk) ? -1
   : prefKeys.includes(bk) && !prefKeys.includes(ak) ? 1
   : prefKeys.includes(ak) && prefKeys.includes(bk)
     ? prefKeys.indexOf(ak) - prefKeys.indexOf(bk)
-  : ak > bk ? 1 : (ak < bk ? -1 : 0)
+  : ak.localeCompare(bk, locale)
 
-const sort = (replacer, seen) => (key, val) => {
+const sort = (replacer, seen, locale) => (key, val) => {
   const prefKeys = Array.isArray(replacer) ? replacer : []
 
   if (typeof replacer === 'function')
@@ -21,7 +21,7 @@ const sort = (replacer, seen) => (key, val) => {
 
   const ret = Object.entries(val).sort(
     ([ak, av], [bk, bv]) =>
-      isObj(av) === isObj(bv) ? compare(ak, bk, prefKeys)
+      isObj(av) === isObj(bv) ? compare(ak, bk, prefKeys, locale)
       : isObj(av) ? 1
       : -1
   ).reduce((set, [k, v]) => {
@@ -33,6 +33,6 @@ const sort = (replacer, seen) => (key, val) => {
   return ret
 }
 
-module.exports = (obj, replacer, space = 2) =>
-  JSON.stringify(obj, sort(replacer, new Map()), space)
+module.exports = (obj, replacer, space = 2, locale) =>
+  JSON.stringify(obj, sort(replacer, new Map(), locale), space)
   + (space ? '\n' : '')

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 const isObj = val => !!val && !Array.isArray(val) && typeof val === 'object'
 
-const compare = (ak, bk, prefKeys, locale) =>
+const compare = (ak, bk, prefKeys) =>
   prefKeys.includes(ak) && !prefKeys.includes(bk) ? -1
   : prefKeys.includes(bk) && !prefKeys.includes(ak) ? 1
   : prefKeys.includes(ak) && prefKeys.includes(bk)
     ? prefKeys.indexOf(ak) - prefKeys.indexOf(bk)
-  : ak.localeCompare(bk, locale)
+  : ak.localeCompare(bk, 'en')
 
-const sort = (replacer, seen, locale) => (key, val) => {
+const sort = (replacer, seen) => (key, val) => {
   const prefKeys = Array.isArray(replacer) ? replacer : []
 
   if (typeof replacer === 'function')
@@ -21,7 +21,7 @@ const sort = (replacer, seen, locale) => (key, val) => {
 
   const ret = Object.entries(val).sort(
     ([ak, av], [bk, bv]) =>
-      isObj(av) === isObj(bv) ? compare(ak, bk, prefKeys, locale)
+      isObj(av) === isObj(bv) ? compare(ak, bk, prefKeys)
       : isObj(av) ? 1
       : -1
   ).reduce((set, [k, v]) => {
@@ -33,6 +33,6 @@ const sort = (replacer, seen, locale) => (key, val) => {
   return ret
 }
 
-module.exports = (obj, replacer, space = 2, locale) =>
-  JSON.stringify(obj, sort(replacer, new Map(), locale), space)
+module.exports = (obj, replacer, space = 2) =>
+  JSON.stringify(obj, sort(replacer, new Map()), space)
   + (space ? '\n' : '')


### PR DESCRIPTION
this update will sort keys as native `.sort()` which is `C.UTF-8` (POSIX) sort - not locale independent.

this will fix locale sorting problem in npm's `package-lock.json` https://github.com/npm/cli/issues/2829

same problem was fixed in 2017 https://github.com/npm/npm/pull/17844/files but now sorting package.json and package-lock.json are again locale independend in npm 7

for me this is a big issue, because some of us in our company is working with english OS, some in slovak and both package.json and package-lock files are changing with every `npm install`

if you are on `*nix` system, you can test `LC_ALL=sk node test.js` and `LC_ALL=en-US node test.js` with node 14 (node < 14 dont have full-icu, so only en-US was supported) to see different output of this library for example `ch` is 1 character is slovak language and its between `h` and `i`, but in english it's 2 character, so it is between `b` and `d`

test.js:
```js
const stringify = require('./index');
console.log(stringify({ b:1, d:1 ,ch:1 }));
```

result:
```
$ LC_ALL=sk node test.js
{
  "b": 1,
  "d": 1,
  "ch": 1
}

$ LC_ALL=en-US node test.js
{
  "b": 1,
  "ch": 1,
  "d": 1
}
```

I was trying to fix this by forcing `en-US` locale, but, `C` and `en-US` sort is not the same; for example `-` is after `_` in en-US, but before in C.
so npm 7 again don't have same sorting as npm 6, when 2017 fix (above) was applied and was using native C sort